### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yaml
+++ b/src/@orb.yaml
@@ -2,4 +2,7 @@ version: 2.1
 
 description: |
   Install the Cloudsmith CLI and publish packages to Cloudsmith.
-  Source: https://github.com/cloudsmith-io/orb
+
+display:
+  home_url: https://cloudsmith.io/
+  source_url: https://github.com/cloudsmith-io/orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.