### PR TITLE
Add OIDC command and add ability to use Cloudsmith CLI zipapp

### DIFF
--- a/src/commands/authenticate-with-oidc.yml
+++ b/src/commands/authenticate-with-oidc.yml
@@ -1,5 +1,5 @@
 description: >
-  Authenticate with Cloudsmith using OpenID Connect (OIDC) to generate a 
+  Authenticate with Cloudsmith using OpenID Connect (OIDC) to generate a
   short-lived OIDC token for use in subsequent Cloudsmith requests. This
   sets the CLOUDSMITH_API_KEY environment variable to the retrieved token
   for use with the Cloudsmith CLI.
@@ -17,7 +17,7 @@ steps:
         organization="<<parameters.organization>>"
         service_account="<<parameters.service-account>>"
         oidc_endpoint="https://api.cloudsmith.io/openid/$organization/"
-        
+
         payload=$(jq -n \
             --arg oidc_token "$CIRCLE_OIDC_TOKEN_V2" \
             --arg service_slug "$service_account" \
@@ -26,14 +26,14 @@ steps:
                 service_slug: $service_slug
             }'
         )
-        
+
         response=$(curl -X POST \
             -H "Content-Type: application/json" \
             -d "$payload" \
             --silent \
             "$oidc_endpoint"
         )
-        
+
         token=$(echo "$response" | jq -r '.token')
         echo "export CLOUDSMITH_API_KEY=$token" >> "$BASH_ENV"
         source "$BASH_ENV"

--- a/src/commands/authenticate-with-oidc.yml
+++ b/src/commands/authenticate-with-oidc.yml
@@ -1,0 +1,39 @@
+description: >
+  Authenticate with Cloudsmith using OpenID Connect (OIDC) to generate a 
+  short-lived OIDC token for use in subsequent Cloudsmith requests. This
+  sets the CLOUDSMITH_API_KEY environment variable to the retrieved token
+  for use with the Cloudsmith CLI.
+parameters:
+  organization:
+    type: string
+    description: The name of the Cloudsmith organization to use for authentication
+  service-account:
+    type: string
+    description: The name of the Cloudsmith service account to use for authentication
+steps:
+  - run:
+      name: Authenticate to Cloudsmith with OIDC
+      command: |
+        organization="<<parameters.organization>>"
+        service_account="<<parameters.service-account>>"
+        oidc_endpoint="https://api.cloudsmith.io/openid/$organization/"
+        
+        payload=$(jq -n \
+            --arg oidc_token "$CIRCLE_OIDC_TOKEN_V2" \
+            --arg service_slug "$service_account" \
+            '{
+                oidc_token: $oidc_token,
+                service_slug: $service_slug
+            }'
+        )
+        
+        response=$(curl -X POST \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            --silent \
+            "$oidc_endpoint"
+        )
+        
+        token=$(echo "$response" | jq -r '.token')
+        echo "export CLOUDSMITH_API_KEY=$token" >> "$BASH_ENV"
+        source "$BASH_ENV"

--- a/src/commands/install-cli.yml
+++ b/src/commands/install-cli.yml
@@ -1,7 +1,7 @@
 description: >
   This command uses pip to install the Cloudsmith CLI from PyPI into the CI
   environment, or falls back to downloading the latest zipapp if pip is not
-  available. The Cloudsmith CLI is used for publishing packages to Cloudsmith 
+  available. The Cloudsmith CLI is used for publishing packages to Cloudsmith
   from your build jobs.
 steps:
   - run:

--- a/src/commands/install-cli.yml
+++ b/src/commands/install-cli.yml
@@ -1,8 +1,8 @@
 description: >
   This command uses pip to install the Cloudsmith CLI from PyPI into the CI
-  environment. The Cloudsmith CLI is used for publishing packages to Cloudsmith
-  from your build jobs. This command requires that pip is installed and
-  available within the build environment or it will fail to run.
+  environment, or falls back to downloading the latest zipapp if pip is not
+  available. The Cloudsmith CLI is used for publishing packages to Cloudsmith 
+  from your build jobs.
 steps:
   - run:
       name: Install Cloudsmith CLI
@@ -16,8 +16,9 @@ steps:
               $PIP install cloudsmith-cli --upgrade --user
             fi
           else
-            echo "Unable to install Cloudsmith CLI. Please install pip."
-            exit 1
+            latest_pyz=$(curl -s https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases/latest | jq -r '.assets[] | select(.name | endswith(".pyz")) | .browser_download_url')
+            curl -L $latest_pyz -o /home/circleci/bin/cloudsmith
+            chmod +x /home/circleci/bin/cloudsmith
           fi
         else
           echo "Cloudsmith CLI is already installed."


### PR DESCRIPTION
- Added an authenticate-with-oidc command which gets a token and sets the CLOUDSMITH_API_KEY for authentication.
- Updated the install-cli command to download the latest CLI zipapp if pip is not available to install cloudsmith-cli from PyPI.