### PR TITLE
chore(no-ticket): add github templates and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@cloudsmith-ceng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@cloudsmith-ceng
+* @cloudsmith-io/customer-engineering

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a problem with the Cloudsmith orb
+title: "[Bug]: "
+---
+
+## Summary
+
+Describe the problem.
+
+## What You Expected
+
+Describe the behavior you expected.
+
+## What Happened
+
+Describe what actually happened, including any error output.
+
+## Relevant Config
+
+Provide the relevant CircleCI config or orb usage snippet.
+
+```yaml
+# Paste config here
+```
+
+## Additional Context
+
+Add anything else that might help reproduce or explain the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an improvement for the Cloudsmith orb
+title: "[Feature]: "
+---
+
+## Summary
+
+Describe the feature or improvement you want.
+
+## Problem or Use Case
+
+Explain the problem this would solve or the workflow it would improve.
+
+## Proposed Solution
+
+Describe the change you would like to see.
+
+## Alternatives Considered
+
+Describe any alternatives you have considered.
+
+## Additional Context
+
+Add any extra context, examples, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+# Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactoring
+- [ ] Other (please describe)
+
+## Additional Notes
+
+<!-- Any additional context or screenshots -->


### PR DESCRIPTION
# Description

* Add templates for PR, Issue and Feature requests.
* Add @cloudsmith-io/customer-engineering as code owners

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

n/a